### PR TITLE
Allow illuminate/contracts ^13.0 for Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.2",
         "filament/filament": "^4.1|^5.1",
-        "illuminate/contracts": "^11.28|^12.0"
+        "illuminate/contracts": "^11.28|^12.0|^13.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

Adds `^13.0` to the `illuminate/contracts` constraint so the package can be installed in Laravel 13 applications using Filament 5.

## Motivation

The current `composer.json` constraint blocks Laravel 13 projects. This is a minimal, backwards-compatible widening of the existing constraint.

## Changes

- Allow `illuminate/contracts` `^13.0` alongside existing `^11.28` and `^12.0` constraints.

## Test plan

- [x] Package installs in a Laravel 13 + Filament 5 project
- [ ] Maintainer verifies no breaking changes for Laravel 11/12 consumers